### PR TITLE
Prefer the chrome extension dev tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,59 @@ ngRedux.subscribe(() => {
 
 This means that you are free to use Redux basic API in advanced cases where `connect`'s API would not fill your needs.
 
-
 ## Using DevTools
 
-In order to use Redux DevTools with your angular app, you need to install [react](https://www.npmjs.com/package/react), [react-redux](https://www.npmjs.com/package/react-redux) and [redux-devtools](https://www.npmjs.com/package/redux-devtools) as development dependencies.
+Ng2Redux is fully compatible with the Chrome extension version of the Redux dev tools:
 
-You can find a sample devtools implentation in the [counter example](https://github.com/wbuchwalter/ng2-redux/blob/master/examples/counter/devTools.js)
+https://github.com/zalmoxisus/redux-devtools-extension
+
+Here's how to enable them in your app (you probably only want to do
+this in development mode):
+
+1. Add the extension to your storeEnhancers:
+
+```typescript
+const enhancers = [];
+
+// Add Whatever other enhancers you want.
+
+if (__DEVMODE__ && window.devToolsExtension) {
+  enhancers = [ ...enhancers, window.devToolsExtension() ];
+}
+
+const store = compose(
+    applyMiddleware(middleware),
+    ...enhancers
+  )(createStore)(rootReducer, initialState);
+```
+
+2. Make Angular 2 update when store events come from the dev tools
+instead of Ng2Redux:
+
+```typescript
+@Component({
+  // etc.
+})
+export class App {
+  private unsubscribe: () => void;
+
+  constructor(
+    private ngRedux: NgRedux<IAppState>,
+    applicationRef: ApplicationRef) {
+
+    // etc.
+
+    if (__DEVMODE__) {
+      this.unsubscribe = ngRedux.subscribe(() => {
+        applicationRef.tick();
+      });
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+  }
+};
+```

--- a/examples/counter/containers/App.ts
+++ b/examples/counter/containers/App.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnDestroy} from 'angular2/core';
+import {Component, Inject, OnDestroy, ApplicationRef} from 'angular2/core';
 import {Observable} from 'rxjs';
 import {AsyncPipe} from 'angular2/common';
 import {Counter} from '../components/Counter';
@@ -24,22 +24,30 @@ import {RootState} from '../store/configureStore';
 export class App {
     
     counter$: any;
+    unsubscribe: () => void;
 
     // Will be added to instance with mapDispatchToTarget
 
     increment: () => any;
     decrement: () => any;
-    
-    constructor(private ngRedux: NgRedux<RootState>,
-        @Inject('devTools') private devTools) {
-    }
+
+    constructor(
+        private ngRedux: NgRedux<RootState>,
+        private applicationRef: ApplicationRef) {}
 
     ngOnInit() {
         let {increment, decrement } = CounterActions;
-        this.devTools.start(this.ngRedux);
         this.counter$ = this.ngRedux
             .select(state => state.counter)
         this.ngRedux.mapDispatchToTarget({ increment, decrement })(this);
+
+        this.unsubscribe = this.ngRedux.subscribe(() => {
+          this.applicationRef.tick();
+        });
+    }
+
+    ngOnDestroy() {
+        this.unsubscribe();
     }
 
     // Can also call ngRedux.dispatch directly

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -26,7 +26,6 @@
     "es6-shim": "^0.35.0",
     "react": "^0.14.8",
     "redux": "^3.4.0",
-    "redux-devtools": "^2.1.0",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^0.1.0",
     "reflect-metadata": "^0.1.3",

--- a/examples/counter/store/configureStore.ts
+++ b/examples/counter/store/configureStore.ts
@@ -2,7 +2,12 @@ import * as Redux from 'redux';
 const {createStore, applyMiddleware, compose} = Redux;
 const thunk = require('redux-thunk');
 import reducer from '../reducers/index';
-const devTools = require('redux-devtools').devTools;
+
+const enhancers = [];
+
+if (window.devToolsExtension) {
+  enhancers.push(window.devToolsExtension);
+}
 
 export interface RootState {
   counter: number;
@@ -10,7 +15,7 @@ export interface RootState {
 
 const finalCreateStore = <Redux.CreateStore<RootState>>compose(
   applyMiddleware(thunk),
-  devTools()
+  ...enhancers
 )(createStore);
 
 export default () => {

--- a/examples/counter/store/utils.d.ts
+++ b/examples/counter/store/utils.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  devToolsExtension?: () => void;
+}


### PR DESCRIPTION
This is because they don't require a dependency on React.

Also showed an example of enabling Angular 2 to refresh after events fired by the dev tools.