### PR TITLE
docs(readme): Update readme connects #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,12 +233,12 @@ export class SessionActions {
   // Here's an action creator that uses HTTP.
   loginUser(credentials) {
     return (dispatch, getState) => {
-      dispatch(LOGIN_USER_PENDING);
+      dispatch({type: LOGIN_USER_PENDING});
 
       this.http.post('/auth/login', credentials)
         .toPromise()
-        .then(response => dispatch(LOGIN_USER_SUCCESS, response.json())
-        .catch(error => dispatch(LOGIN_USER_ERROR, error);
+        .then(response => dispatch({type: LOGIN_USER_SUCCESS, payload: response.json()})
+        .catch(error => dispatch({type: LOGIN_USER_ERROR, payload: error, error: true });
       });
     };
   }


### PR DESCRIPTION
* Update example to dispatch with a type property, related to #71 where
  the fact that dispatch should return a JSON object with a type
  property wasn't clear.

@SethDavenport 