### PR TITLE
feat(select): Custom comparer in select decorator

### DIFF
--- a/src/___tests___/decorators/select.spec.ts
+++ b/src/___tests___/decorators/select.spec.ts
@@ -37,72 +37,72 @@ describe('@select', () => {
   describe('when passed no arguments', () => {
 
     it('automatically attempts to bind to a store property that matches the' +
-       ' name of the class property', () => {
+      ' name of the class property', () => {
 
-      class MockClass {
-        @select() baz: any;
-      }
+        class MockClass {
+          @select() baz: any;
+        }
 
-      let mockInstance = new MockClass();
-      let value;
-      let expectedValue = 1;
+        let mockInstance = new MockClass();
+        let value;
+        let expectedValue = 1;
 
-      mockInstance.baz.subscribe((val) => {
-        value = val;
+        mockInstance.baz.subscribe((val) => {
+          value = val;
+        });
+
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+
+        expect(value).to.equal(expectedValue);
+
       });
-
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-
-      expect(value).to.equal(expectedValue);
-
-    });
 
     it('attempts to bind by name ignoring any $ characters in the class ' +
-       'property name', () => {
+      'property name', () => {
 
-      class MockClass {
-        @select() baz$: any;
-      }
+        class MockClass {
+          @select() baz$: any;
+        }
 
-      let mockInstance = new MockClass();
-      let value;
-      let expectedValue = 2;
+        let mockInstance = new MockClass();
+        let value;
+        let expectedValue = 2;
 
-      mockInstance.baz$.subscribe((val) => {
-        value = val;
+        mockInstance.baz$.subscribe((val) => {
+          value = val;
+        });
+
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+
+        expect(value).to.equal(expectedValue);
+
+
       });
-
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-
-      expect(value).to.equal(expectedValue);
-
-
-    });
 
   });
 
   describe('when passed a string', () => {
 
     it('attempts to bind to the store property whose name matches the ' +
-       'string value', () => {
+      'string value', () => {
 
-      class MockClass {
-        @select('baz') asdf: any;
-      }
+        class MockClass {
+          @select('baz') asdf: any;
+        }
 
-      let mockInstance = new MockClass();
-      let value;
-      let expectedValue = 3;
+        let mockInstance = new MockClass();
+        let value;
+        let expectedValue = 3;
 
-      mockInstance.asdf.subscribe((val) => {
-        value = val;
+        mockInstance.asdf.subscribe((val) => {
+          value = val;
+        });
+
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+
+        expect(value).to.equal(expectedValue);
+
       });
-
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-
-      expect(value).to.equal(expectedValue);
-
-    });
 
   });
 
@@ -122,12 +122,46 @@ describe('@select', () => {
         value = val;
       });
 
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue / 2});
+      ngRedux.dispatch({ type: 'nvm', payload: expectedValue / 2 });
 
       expect(value).to.equal(expectedValue);
 
     });
 
+  });
+
+  describe('when using a custom comprarer', () => {
+    it('should use the provided compare function', () => {
+      
+      let compare = sinon.spy((a, b) => a.foo === b.foo); 
+      let stateSpy = sinon.spy((foo) => ({}));
+      let state2Spy = sinon.spy((foo) => ({}));
+
+      class MockClass {
+        @select(state => state, compare) state$: any;
+        @select(state => state) state2$: any; 
+      }
+
+      let mockInstance = new MockClass();
+      let state = mockInstance.state$.subscribe(stateSpy);
+      let state2 = mockInstance.state2$.subscribe(state2Spy);
+
+            
+      expect(stateSpy).to.have.been.calledOnce;
+      expect(state2Spy).to.have.been.calledOnce;
+
+      ngRedux.dispatch({ type: 'nvm', payload: 'magic' });
+      expect(compare).to.have.been.called;
+
+      // since the custom compare is only looking at the
+      // foo key, it doesn't care about changes to baz
+      // even though the state is changing fully
+
+      expect(stateSpy).to.have.been.calledOnce;
+      expect(state2Spy).to.have.been.calledTwice;
+      
+      
+    });
   });
 
 });

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -7,8 +7,12 @@ import { NgRedux } from '../components/ng-redux';
  * @param {string | function} stateKeyOrFunc 
  * An Rxjs selector function or a string indicating the name of the store
  * property to be selected.
- * */
-export const select = <T>(stateKeyOrFunc?) => (target, key) => {
+ * @param {(x: any, y: any) => boolean} [comparer] Optional
+ * comparison function called to test if an item is distinct
+ * from the previous item in the source.
+ **/
+export const select = <T>(stateKeyOrFunc?,
+    comparer?: (x: any, y: any) => boolean) => (target, key) => {
     let bindingKey = (key.lastIndexOf('$') === key.length - 1) ?
         key.substring(0, key.length - 1) : key;
 
@@ -19,7 +23,7 @@ export const select = <T>(stateKeyOrFunc?) => (target, key) => {
     function getter() {
         return NgRedux.instance
             .select(typeof stateKeyOrFunc === 'function' ?
-                    stateKeyOrFunc : bindingKey);
+                    stateKeyOrFunc : bindingKey, comparer);
     }
 
     // Delete property.


### PR DESCRIPTION
ngRedux.select has the ability to pass in a custom compare function,
didn't have this on the `@select` decorator, added this.

```js
let compare = (a,b) => a.x === b.x
class MyComponent() {
  @select(state=>state,compare) state$:Obserable<any>;
}
```