### PR TITLE
moved typings to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "ts-loader": "^0.8.1",
     "ts-node": "^0.5.5",
     "typescript": "^1.8.10",
-    "typings": "^1.0.4",
     "zone.js": "0.6.12"
   },
   "peerDependencies": {
     "rxjs": "5.0.0-beta.6",
     "@angular/core": "2.0.0-rc.1",
+    "typings": "^1.0.4",
     "zone.js": "0.6.12"
   },
   "dependencies": {}


### PR DESCRIPTION
when including ng2-redux as a dev-dependency in my project, ```npm install``` fails due to 
```

> ng2-redux@2.3.4 postinstall /opt/atlassian/bitbucketci/agent/build/node_modules/ng2-redux
> typings install

sh: 1: typings: not found
```

moving it to peer-dependencies should ensure that typings is installed before ng2-redux's post-install script is run.