### PR TITLE
SystemJS friendliness.

### DIFF
--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,1 +1,0 @@
-export { select } from './select';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { NgRedux } from './components/ng-redux';
-export { select } from './decorators';
+export { select } from './decorators/select';
 


### PR DESCRIPTION
Relying on folder level `index.ts` files makes systemJS harder to configure. Might as well do the simple thing and be explicit in the one place we were using this pattern.