### PR TITLE
Adding comparer to select decorator.

### DIFF
--- a/examples/counter/actions/counter-actions.ts
+++ b/examples/counter/actions/counter-actions.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { NgRedux } from 'ng2-redux';
-import * as Redux from 'redux';
 import { RootState } from '../store';
 import { RandomNumberService } from '../services/random-number';
 

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -3,7 +3,6 @@ import * as Redux from 'redux';
 import {
     Store,
     Action,
-    ActionCreator,
     Reducer,
     createStore,
     applyMiddleware,

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -4,11 +4,15 @@ import { NgRedux } from '../components/ng-redux';
  * Selects an observable from the store, and attaches it to the decorated 
  * property.
  *
- * @param {string | function} stateKeyOrFunc 
+ * @param {string | function} stateKeyOrFunc
+ * @param {function} comparer function for this selector
  * An Rxjs selector function or a string indicating the name of the store
  * property to be selected.
  * */
-export const select = <T>(stateKeyOrFunc?) => (target, key) => {
+export const select = <T>(
+    stateKeyOrFunc?,
+    comparer?: (x: any, y: any) => boolean) => (target, key) => {
+
     let bindingKey = (key.lastIndexOf('$') === key.length - 1) ?
         key.substring(0, key.length - 1) : key;
 
@@ -17,9 +21,9 @@ export const select = <T>(stateKeyOrFunc?) => (target, key) => {
     }
 
     function getter() {
+      const isFunction = typeof stateKeyOrFunc === 'function';
         return NgRedux.instance
-            .select(typeof stateKeyOrFunc === 'function' ?
-                    stateKeyOrFunc : bindingKey);
+            .select(isFunction ? stateKeyOrFunc : bindingKey, comparer);
     }
 
     // Delete property.


### PR DESCRIPTION
I was playing around with select and ng2-redux, it worked for all use cases, code is very clean, and it looks awesome guys. 
I don't know if this is useful, but since our select method already supports this feature I thought it'd be interesting to have the comparer function as an argument for @select as well.
Comparer function to select a particular property seems useless, at least using with immutable. The default comparer already deals with it even if the same immutable slice gets updated in another sibling (which would generate a new object). 
I wonder if when selecting just the slice might be a good shot. Thoughts?