### PR TITLE
Prepare v3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
-# 3.0.6
+# 3.1.0
 
 ### Features
 
-Added a 'path' option to `ngRedux.select()` and `@select()`. Now you can
+* Added a 'path' option to `ngRedux.select()` and `@select()`. Now you can
 do stuff like `@select(['foo', 'bar'])` to select `state.foo.bar` into
 an observable.
+
+* Add ability to provide custom comparer to @select decorator to keep consistent with ngRedux.select
+
+```js
+import { is } from 'immutablejs'
+
+export class SomeComponent { 
+  @select(n=n.some.selector, is) someSelector$: Observable<any>
+}
+
+```
+### Features
+
+# 3.0.8
+
+### Fix
+
+* AppliicationRef is optional dependency, fixes#127
 
 # 3.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-redux",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
@SethDavenport @danielfigueiredo prepping 3.1 release - version bump + details in changelog 

Since we are adding new features, minor version bump instead of a patch, no breaking changes that I'm aware of. 