### PR TITLE
Allow subscription to ngRedux in @Injectable

### DIFF
--- a/examples/counter/components/Counter.ts
+++ b/examples/counter/components/Counter.ts
@@ -27,5 +27,11 @@ export class Counter {
   @select([ 'pathDemo', 'foo' ]) foo$;
   @select([ 'pathDemo', 'foo', 'bar', 0 ]) bar$: number;
 
-  constructor(private actions: CounterActions) {}
+  constructor(private actions: CounterActions, private random: RandomNumberService) { }
+  ngOnInit() {
+    this.random.counter$.subscribe(n => {
+      console.log('Helllo', n);
+    })
+  }
+  
 }

--- a/examples/counter/containers/App.ts
+++ b/examples/counter/containers/App.ts
@@ -5,7 +5,7 @@ import { NgRedux } from 'ng2-redux';
 import { Counter } from '../components/Counter';
 import { CounterInfo } from '../components/CounterInfo';
 import { RootState, enhancers } from '../store';
-
+import { RandomNumberService } from '../services/random-number';
 import reducer from '../reducers/index';
 const createLogger = require('redux-logger');
 
@@ -14,19 +14,25 @@ const createLogger = require('redux-logger');
     directives: [Counter, CounterInfo],
     pipes: [AsyncPipe],
     template: `
+
     <counter></counter>
     <counter-info></counter-info>
+    <p>
+    Random Number Service @select: {{r.counter$ | async}}  
+    </p>
+    <p>
+    Random Number Service .select: {{r.counter}}  
+    </p>
   `
 })
 export class App {
-
-    constructor(private ngRedux: NgRedux<any>) {
-
+    constructor(private ngRedux: NgRedux<any>,
+        private r: RandomNumberService) {
         // Do this once in the top-level app component.
         this.ngRedux.configureStore(
             reducer,
             {},
-            [ createLogger() ],
+            [createLogger()],
             enhancers
         );
 

--- a/examples/counter/index.ts
+++ b/examples/counter/index.ts
@@ -1,5 +1,5 @@
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { App } from './containers/App';
 import { NgRedux } from 'ng2-redux';
-
-bootstrap(App, [ NgRedux ]);
+import { RandomNumberService } from './services/random-number';
+bootstrap(App, [ NgRedux, RandomNumberService ]);

--- a/examples/counter/services/random-number.ts
+++ b/examples/counter/services/random-number.ts
@@ -1,11 +1,18 @@
 import { Injectable } from '@angular/core';
-
+import { select, NgRedux } from 'ng2-redux';
 /**
  * Simple service designed to demonstrate using a DI-injected
  * service in your action creators.
  */
 @Injectable()
 export class RandomNumberService {
+  @select('counter') counter$: any;
+  counter: number; 
+  constructor(private ngRedux: NgRedux<any>) { 
+    ngRedux.select(n => n.counter).subscribe(n => {
+      this.counter = n;
+    });
+  }
   pick() {
     return Math.floor(Math.random() * 100);
   }

--- a/src/___tests___/components/ng-redux.spec.ts
+++ b/src/___tests___/components/ng-redux.spec.ts
@@ -6,7 +6,7 @@ import { NgRedux } from '../../components/ng-redux';
 import { select } from '../../decorators/select';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
-
+import 'rxjs/add/operator/combineLatest';
 use(sinonChai);
 
 function returnPojo() {

--- a/src/___tests___/components/ng-redux.spec.ts
+++ b/src/___tests___/components/ng-redux.spec.ts
@@ -277,30 +277,78 @@ describe('NgRedux Observable Store', () => {
 
   it('should throw when the store is provided after it has been configured',
     () => {
-    // Configured once in beforeEach, now we try to provide a store when
-    // we already have configured one.
+      // Configured once in beforeEach, now we try to provide a store when
+      // we already have configured one.
 
-    expect(ngRedux.provideStore.bind(store))
-      .to.throw(Error);
-  });
+      expect(ngRedux.provideStore.bind(store))
+        .to.throw(Error);
+    });
 
   it('should set the store when a store is provided',
     () => {
 
-    delete ngRedux._store;
-    delete ngRedux._$store;
+      delete ngRedux._store;
+      delete ngRedux._$store;
 
-    expect(ngRedux._store).to.be.undefined;
-    expect(ngRedux._$store).to.be.undefined;
+      expect(ngRedux._store).to.be.undefined;
+      expect(ngRedux._$store).to.be.undefined;
 
-    expect(ngRedux.provideStore.bind(ngRedux, store))
-      .to.not.throw(Error);
+      expect(ngRedux.provideStore.bind(ngRedux, store))
+        .to.not.throw(Error);
 
-    expect(ngRedux._store).to.have.all.keys(
-      'dispatch',
-      'subscribe',
-      'getState',
-      'replaceReducer'
-    );
-  });
+      expect(ngRedux._store).to.have.all.keys(
+        'dispatch',
+        'subscribe',
+        'getState',
+        'replaceReducer'
+      );
+    });
+
+  it('should wait until store is configured before emitting values',
+    () => {
+      class SomeService {
+        foo: string;
+        bar: string;
+        baz: number;
+
+        constructor(private _ngRedux: NgRedux<any>) {
+          _ngRedux.select(n => n.foo).subscribe(foo => this.foo = foo);
+          _ngRedux.select(n => n.bar).subscribe(bar => this.bar = bar);
+          _ngRedux.select(n => n.baz).subscribe(baz => this.baz = baz);
+        }
+      }
+      ngRedux = new NgRedux<IAppState>(mockAppRef);
+
+      let someService = new SomeService(ngRedux);
+      ngRedux.configureStore(rootReducer, defaultState);
+      expect(someService.foo).to.be.equal('bar');
+      expect(someService.bar).to.be.equal('foo');
+      expect(someService.baz).to.be.equal(-1);
+
+    });
+
+  it('should have select decorators work before store is configured',
+    (done) => {
+      class SomeService {
+        @select() foo$: any;
+        @select() bar$: any;
+        @select() baz$: any;
+
+      }
+      ngRedux = new NgRedux<IAppState>(mockAppRef);
+
+      let someService = new SomeService();
+      someService
+        .foo$
+        .combineLatest(someService.bar$, someService.baz$)
+        .subscribe(([foo, bar, baz]) => {
+          expect(foo).to.be.equal('bar');
+          expect(bar).to.be.equal('foo');
+          expect(baz).to.be.equal(-1);
+          done();
+        });
+
+      ngRedux.configureStore(rootReducer, defaultState);
+
+    });
 });

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -299,7 +299,7 @@ export class NgRedux<RootState> {
      */
     private setStore(store: Store<RootState>) {
         this._store = store;
-        
+        this._store$.next(this._store.getState());
         this._store.subscribe(() => this._store$.next(this._store.getState()));
 
         this._defaultMapStateToTarget = () => ({});


### PR DESCRIPTION
When trying to use `ngRedux.select()` in constructor code in your
services, there was a chance that the store had not been configured yet
and would throw errors.

Updated code so store$ starts off as an initalized BehaviorSubject, and
the exposed streams off of it will filter for 'null' values first,
ensuring that downstream subscribers will have a proper observable, and
also the correct version of app state.