### PR TITLE
Remove appref.tick() stuff.

### DIFF
--- a/src/___tests___/components/ng-redux.spec.ts
+++ b/src/___tests___/components/ng-redux.spec.ts
@@ -13,10 +13,6 @@ function returnPojo() {
   return {};
 }
 
-class MockApplicationRef {
-  tick: () => void;
-}
-
 describe('Connector', () => {
   let ngRedux;
   let targetObj;
@@ -37,7 +33,7 @@ describe('Connector', () => {
     mockAppRef = {
       tick: sinon.spy()
     };
-    ngRedux = new NgRedux(mockAppRef);
+    ngRedux = new NgRedux();
     ngRedux.configureStore(rootReducer, defaultState);
   });
 
@@ -59,7 +55,6 @@ describe('Connector', () => {
     expect(ngRedux.connect.bind(ngRedux, state => state.foo))
       .to.throw(Error);
   });
-
 
   it('Should extend target (Object) with selected state once directly after ' +
     'creation', () => {
@@ -158,11 +153,7 @@ describe('NgRedux Observable Store', () => {
       }
     };
 
-    mockAppRef = {
-      tick: sinon.spy()
-    };
-
-    ngRedux = new NgRedux<IAppState>(mockAppRef);
+    ngRedux = new NgRedux<IAppState>();
     ngRedux.configureStore(rootReducer, defaultState);
   });
 
@@ -281,12 +272,4 @@ describe('NgRedux Observable Store', () => {
     expect(fooData.data).to.equal('update-2');
     expect(spy).to.have.been.calledThrice;
   });
-
-  it('should force the Angular UI to update when a change is made externally',
-    () => {
-      ngRedux.dispatch({ type: 'UPDATE_FOO', payload: 'update' });
-      expect(mockAppRef.tick).to.have.been.calledOnce;
-    });
-
 });
-

--- a/src/___tests___/decorators/select.spec.ts
+++ b/src/___tests___/decorators/select.spec.ts
@@ -24,10 +24,7 @@ describe('@select', () => {
       return newState;
     };
     targetObj = {};
-    mockAppRef = {
-      tick: sinon.spy()
-    };
-    ngRedux = new NgRedux(mockAppRef);
+    ngRedux = new NgRedux();
     ngRedux.configureStore(rootReducer, defaultState);
   });
 
@@ -156,7 +153,7 @@ describe('@select', () => {
     it('should receive previous and next value for comparison', () => {
 
       const spy = sinon.spy();
-      
+
       class MockClass {
         @select(state => state.baz, spy) asdf: any;
       }
@@ -173,7 +170,5 @@ describe('@select', () => {
       expect(spy.getCall(1).args[0]).to.equal(1);
       expect(spy.getCall(1).args[1]).to.equal(2);
     });
-
   });
-
 });

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -13,7 +13,7 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/distinctUntilChanged';
-import { Injectable, ApplicationRef, Optional } from '@angular/core';
+import { Injectable } from '@angular/core';
 import shallowEqual from '../utils/shallowEqual';
 import wrapActionCreators from '../utils/wrapActionCreators';
 import { isObject, isFunction, isPlainObject} from '../utils/type-checks';
@@ -38,12 +38,8 @@ export class NgRedux<RootState> {
 
     /**
      * Creates an instance of NgRedux.
-     *
-     * @param {ApplicationRef} applicationRef Angular application ref:
-     *  lets redux dev tools refresh the Angular 2 view when it changes
-     *  the store.
      */
-    constructor(@Optional() private _applicationRef?: ApplicationRef) {
+    constructor() {
       NgRedux.instance = this;
     }
 
@@ -76,14 +72,7 @@ export class NgRedux<RootState> {
 
         this._store = store;
         this._store$ = new BehaviorSubject(store.getState());
-        this._store.subscribe(() => {
-            this._store$.next(this._store.getState());
-
-            // For devTools support.
-            if (this._applicationRef) {
-                this._applicationRef.tick();
-            }    
-        });
+        this._store.subscribe(() => this._store$.next(this._store.getState()));
 
         this._defaultMapStateToTarget = () => ({});
         this._defaultMapDispatchToTarget = dispatch => ({ dispatch });


### PR DESCRIPTION
Because it causes an issue with actions that are dispatched from `ngOnInit()`.

This was used to handle updates from the redux devtools extension in earlier betas/release candidates. However it seems that the underlying zone issue has been fixed in RC.3: the devtools appear to work without it.