### PR TITLE
Convenience wrapper for the dev tools extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,29 +476,48 @@ Ng2Redux is fully compatible with the Chrome extension version of the Redux dev 
 
 https://github.com/zalmoxisus/redux-devtools-extension
 
-Here's how to enable them in your app (you probably only want to do
-this in development mode):
+However, due to peculiarities of Angular 2's change detection logic,
+events that come from external tools don't trigger a refresh in Angular's
+zone.
+
+We've taken the liberty of providing a wrapper around the extension
+tools that handles this for you.
+
+Here's how to hook the extension up to your app:
 
 ```typescript
-let enhancers = [];
-
-// Add Whatever other enhancers you want.
-
-if (__DEVMODE__ && window.devToolsExtension) {
-  enhancers = [ ...enhancers, window.devToolsExtension() ];
-}
+import { DevToolsExtension } from 'ng2-redux';
 
 // Add the dev tools enhancer your ngRedux.configureStore called
 // when you initialize your root component:
 @Component({
   // ...
+  providers: [ DevToolsExtension ]
 })
 class App {
-  constructor(private ngRedux: NgRedux) {
-    this.ngRedux.configureStore(rootReducer, initialState, [], enhancers);
+  constructor(
+    private ngRedux: NgRedux,
+    private devTools: DevToolsExtension) {
+
+    let enhancers = [];
+    // ... add Whatever other enhancers you want.
+
+    // You probably only want to expose this tool in devMode.
+    if (__DEVMODE__ && devTools.isEnabled()) {
+      enhancers = [ ...enhancers, devTools.enhancer() ];
+    }
+
+    this.ngRedux.configureStore(
+      rootReducer,
+      initialState,
+      [],
+      enhancers);
   }
 }
 ```
+
+`ReduxDevTools.enhancer()` takes the same options parameter as
+documented here: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#windowdevtoolsextensionconfig
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ class App {
     private devTools: DevToolsExtension) {
 
     let enhancers = [];
-    // ... add Whatever other enhancers you want.
+    // ... add whatever other enhancers you want.
 
     // You probably only want to expose this tool in devMode.
     if (__DEVMODE__ && devTools.isEnabled()) {

--- a/examples/counter/containers/App.ts
+++ b/examples/counter/containers/App.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
-import { NgRedux } from 'ng2-redux';
+import { NgRedux, DevToolsExtension } from 'ng2-redux';
 
 import { Counter } from '../components/Counter';
 import { CounterInfo } from '../components/CounterInfo';
@@ -14,22 +14,22 @@ const createLogger = require('redux-logger');
     directives: [Counter, CounterInfo],
     pipes: [AsyncPipe],
     template: `
-    <counter></counter>
-    <counter-info></counter-info>
-  `
+        <counter></counter>
+        <counter-info></counter-info>
+    `,
+    providers: [ DevToolsExtension ]
 })
 export class App {
-
-    constructor(private ngRedux: NgRedux<any>) {
-
+    constructor(
+        private ngRedux: NgRedux<any>,
+        private devTool: DevToolsExtension) {
         // Do this once in the top-level app component.
         this.ngRedux.configureStore(
             reducer,
             {},
             [ createLogger() ],
-            enhancers
-        );
-
+            devTool.isEnabled() ?
+                [ ...enhancers, devTool.enhancer() ] :
+                enhancers);
     }
-
 }

--- a/examples/counter/store/index.ts
+++ b/examples/counter/store/index.ts
@@ -4,10 +4,6 @@ export const enhancers = [
   persistState('counter', { key: 'ng2-redux/examples/counter' })
 ];
 
-if (window.devToolsExtension) {
-  enhancers.push(window.devToolsExtension());
-}
-
 export interface RootState {
   counter: number;
   pathDemo: Object;

--- a/src/components/dev-tools.ts
+++ b/src/components/dev-tools.ts
@@ -14,7 +14,8 @@ export class DevToolsExtension {
    * trigger Angular2's change detector.
    *
    * @argument { Object } options: dev tool options; same
-   * format as described here: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#windowdevtoolsextensionconfig
+   * format as described here: 
+   * [zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md]
    */
   enhancer = (options) => {
     if (!this.isEnabled()) {

--- a/src/components/dev-tools.ts
+++ b/src/components/dev-tools.ts
@@ -1,0 +1,35 @@
+import { Injectable, ApplicationRef } from '@angular/core';
+const environment: any = window || this;
+
+/**
+ * An angular-2-ified version of the Redux DevTools chrome extension.
+ */
+@Injectable()
+export class DevToolsExtension {
+  constructor(private appRef: ApplicationRef) {}
+
+  /**
+   * A wrapper for the Chrome Extension Redux DevTools.
+   * Makes sure state changes triggered by the extension
+   * trigger Angular2's change detector.
+   *
+   * @argument { Object } options: dev tool options; same
+   * format as described here: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#windowdevtoolsextensionconfig
+   */
+  enhancer = (options) => {
+    if (!this.isEnabled()) {
+      return null;
+    }
+
+    // Make sure changes from dev tools update angular's view.
+    environment.devToolsExtension.listen(() => this.appRef.tick());
+    return environment.devToolsExtension(options);
+  }
+
+  /**
+   * Returns true if the extension is installed and enabled.
+   */
+  isEnabled() {
+    return environment && environment.devToolsExtension;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { NgRedux } from './components/ng-redux';
+export { DevToolsExtension } from './components/dev-tools';
 export { select } from './decorators/select';
-


### PR DESCRIPTION
RC4 seems to require the use of AppRef.tick() again to propagate store changes from the dev tools extension.

Since doing it directly in NgRedux is problematic, I've created a wrapper component for it that triggers only for external events (not for actions dispatched in the Angular 2 zone.

This wrapper also neatly hides some of the messiness of accessing `window.devToolsExtension` in TypeScript.