### PR TITLE
Add seamless support for ImmutableJS structures in select() path

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chai": "^3.5.0",
     "es6-shim": "^0.35.0",
     "expect": "^1.8.0",
+    "immutable": "^3.0.0",
     "mocha": "^2.4.5",
     "redux": "^3.4.0",
     "reflect-metadata": "0.1.3",
@@ -66,6 +67,7 @@
   },
   "peerDependencies": {
     "@angular/core": "2.0.0-rc.3 || ^2.0.0-rc.4",
+    "immutable": "^3.0.0",
     "redux": "^3.4.0",
     "rxjs": "5.0.0-beta.6",
     "typings": "^1.0.4",

--- a/src/utils/get-in.ts
+++ b/src/utils/get-in.ts
@@ -1,14 +1,21 @@
+import * as immutable from 'immutable';
+
 /*
  * Gets a deeply-nested property value from an object, given a 'path'
  * of property names or array indices.
  */
 export function getIn(
-  v: Object,
+  v: Object | immutable.Iterable<string, any>,
   pathElems: (string | number)[]): any {
-    const [ firstElem, ...restElems] = pathElems;
     if (!v) {
       return v;
     }
+
+    if (immutable.Iterable.isIterable(v)) {
+      return (<immutable.Iterable<string, any>>v).getIn(pathElems);
+    }
+
+    const [ firstElem, ...restElems] = pathElems;
 
     if (undefined === v[firstElem]) {
       return undefined;
@@ -20,3 +27,4 @@ export function getIn(
 
     return getIn(v[firstElem], restElems);
 }
+


### PR DESCRIPTION
This change allows you to use syntax like @select(['foo', 'bar', 'baz']) where either 'foo' or 'bar' are ImmutableJS structures inside of your Redux state. 