### PR TITLE
Change immutablejs integration approach

### DIFF
--- a/src/utils/get-in.ts
+++ b/src/utils/get-in.ts
@@ -1,24 +1,18 @@
-// This may look suspicious, but the point is to add ImmutableJS integration
-// only if the project itself already has a dependency on immutable. If not,
-// then this variable is left null and no integration is attempted.
-let immutable;
-try {
-  immutable = require('immutable');
-} catch (e) {}
-
 /*
  * Gets a deeply-nested property value from an object, given a 'path'
  * of property names or array indices.
  */
-export function getIn(
-  v: Object,
-  pathElems: (string | number)[]): any {
+export function getIn(v, pathElems: (string | number)[]): any {
     if (!v) {
       return v;
     }
 
-    if (immutable && immutable.Iterable.isIterable(v)) {
-      return (<{getIn: (path: (string | number)[]) => any}>v).getIn(pathElems);
+    // If this is an ImmutableJS structure, use existing getIn function
+    if (typeof v.getIn === 'function') {
+      const result = v.getIn(pathElems);
+      if (result != null) {
+        return result;
+      }
     }
 
     const [ firstElem, ...restElems] = pathElems;

--- a/src/utils/get-in.ts
+++ b/src/utils/get-in.ts
@@ -9,10 +9,7 @@ export function getIn(v, pathElems: (string | number)[]): any {
 
     // If this is an ImmutableJS structure, use existing getIn function
     if (typeof v.getIn === 'function') {
-      const result = v.getIn(pathElems);
-      if (result != null) {
-        return result;
-      }
+      return v.getIn(pathElems);
     }
 
     const [ firstElem, ...restElems] = pathElems;


### PR DESCRIPTION
Instead of using an 'optional' require() statement inside of a try-catch, just look for a 'getIn' function on the data structure passed to getIn(), and if it exists, use it. This eliminates a big nasty Webpack warning.

Fixes #165