### PR TITLE
Bug fix for #172

### DIFF
--- a/src/components/dev-tools.ts
+++ b/src/components/dev-tools.ts
@@ -1,7 +1,7 @@
 import { Injectable, ApplicationRef } from '@angular/core';
 
 declare const window: any;
-const environment: any = window || this;
+const environment: any = typeof window !== 'undefined' ? window : this;
 
 /**
  * An angular-2-ified version of the Redux DevTools chrome extension.


### PR DESCRIPTION
DevTools component throws "ReferenceError: window is not defined" when run on node using Universal. This happens even if you are not including the dev tools enhancer; by virtue of the component being imported in index.ts, the (generated) line below is executed but fails when run in node:

var environment = window || this;

Just added an explicit typeof check around window