### PR TITLE
[Fixes #187] Relax zonejs version.

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -37,7 +37,7 @@
     "redux-localstorage": "^0.4.0",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
-    "zone.js": "0.6.12"
+    "zone.js": "^0.6.12"
   },
   "devDependencies": {
     "babel-core": "^5.5.8",

--- a/package.json
+++ b/package.json
@@ -65,13 +65,13 @@
     "tslint": "^3.11.0",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
-    "zone.js": "0.6.12"
+    "zone.js": "^0.6.12"
   },
   "peerDependencies": {
     "@angular/core": "2.0.0-rc.3 || ^2.0.0-rc.4 || ^2.0.0-rc.5",
     "redux": "^3.5.0",
     "rxjs": "5.0.0-beta.6",
     "typings": "^1.0.4",
-    "zone.js": "0.6.12"
+    "zone.js": "^0.6.12"
   }
 }


### PR DESCRIPTION
Angular itself lists a dependency of ^0.6.5, so we shouldn't be restricting it further.