### PR TITLE
fix dev tools out of sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-redux",
-  "version": "3.3.6-beta.0",
+  "version": "3.3.6-beta.1",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-redux",
-  "version": "3.3.5",
+  "version": "3.3.6-beta.0",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Occasionaly events sent from DevTools will be outside of the Angular
zone and changes won't get reflected. When dev tools start - subscribe
to the store, if not in angular zone - cause a tick for changes to get
reflected.