### PR TITLE
fix(build): No chai for you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 3.3.9
+
+### Fixes
+
+* Temp update to npm build to uninstall typings for chai/sinon-chai so `///  <reference types="chai" />` doesn't get added to files.
+
+# 3.3.8
+
+### Fixes 
+
+* Manual fix of build to remove chai type reference 
+
 # 3.3.7
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "ng2-redux",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {
-    "build": "rimraf ./lib; tsc",
+    "build": "rimraf ./lib; npm uninstall @types/chai @types/sinon-chai; tsc; npm install @types/chai@3.4.31 @types/sinon-chai@2.7.26",
     "test": "rimraf coverage && npm run lint && npm run cover",
     "mocha": "mocha --opts mocha.opts",
     "lint": "tslint 'src/**/*.ts' 'examples/counter/**.ts' --exclude 'examples/counter/node_modules'",


### PR DESCRIPTION
The chai type def has this...

```
interface Object {
    should: Chai.Assertion;
}
```

When we run build, on files that have things like:

`let x = (y:Object):Obect => { }`

In the resulting file.d.ts

```
/// <reference types="chai" />
```

Gets added, causing things to blow up for people. Not good.

Temp fix for now - when running build, uninstall the types - then
re-install them after.

Not happy with this, but rather this than having a patch causing
breaking builds for using 3.3.8.