### PR TITLE
Fix/generic aot fun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
-# 4.0.0-beta.6
+# 4.0.0
 
-### Fixes / Features 
+### Features 
 
-Sorry for the delay on this, was hoping to get AoT working for decorators also - but there seems to be some challenges around that.
+* Better support for Angular CLI
+* NgModule interface changes to better support Angular 2's ahead-of-time compiler (AoT)
+
+### Fixes
 
 * Update build to use ngc - metadata.json is now produced
-* Fix `Unexpected value 'NgReduxModule' imported`
-* NgReduxModule
+* Introduced NgReduxModule
+* Fix AoT related bugs #247, #235, #228
 
-### Using NgReduxModule 
+### Breaking Change: Using NgReduxModule 
 
 ```js
 import { BrowserModule } from '@angular/platform-browser';
@@ -17,6 +20,7 @@ import { AppComponent } from './app.component';
 import { NgReduxModule, NgRedux } from 'ng2-redux';
 import { IAppState } from './appstate';
 import { rootReducer } from './store';
+
 @NgModule({
   declarations: [
     AppComponent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-redux",
-  "version": "4.0.0-aotfun.2",
+  "version": "4.0.0-beta.9",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-redux",
-  "version": "4.0.0-beta.7",
+  "version": "4.0.0-aotfun.2",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -16,7 +16,7 @@ import 'rxjs/add/operator/filter';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/switchMap';
-import { Injectable, Optional, ApplicationRef } from '@angular/core';
+import { Optional, ApplicationRef } from '@angular/core';
 
 import shallowEqual from '../utils/shallow-equal';
 import wrapActionCreators from '../utils/wrap-action-creators';
@@ -40,7 +40,6 @@ export type Comparator = (x: any, y: any) => boolean;
 // released.
 type RetypedCompose = (func: Function, ...funcs: Function[]) => Function;
 
-@Injectable()
 export class NgRedux<RootState> {
     private _store: Store<RootState> = null;
     private _store$: BehaviorSubject<RootState> = null;


### PR DESCRIPTION
Attempt to fix the 'generic' AOT issue. Since we manually create a provider in `NgReduxModule.forRoot()`, the `@Injectable` decorator is redundant on `NgRedux`. I'm working on the theory that the `Injectable` with the generic type is what's causing AoT to barf.