### PR TITLE
Fixes build with ngc 2.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp/
 lib/
 .nyc_output/
 coverage/
+*.ngsummary.json

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/index.js",
   "scripts": {
+    "prepublish": "npm run build",
     "prebuild": "rimraf ./lib; npm uninstall @types/chai @types/sinon-chai;",
     "postbuild": "npm install @types/chai@3.4.31 @types/sinon-chai@2.7.26; rimraf \"src/**/*.ngfactory.ts\"",
     "build": "ngc -p tsconfig.json;",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "scripts": {
     "prepublish": "npm run build",
-    "prebuild": "rimraf ./lib; npm uninstall @types/chai @types/sinon-chai;",
-    "postbuild": "npm install @types/chai@3.4.31 @types/sinon-chai@2.7.26; rimraf \"src/**/*.ngfactory.ts\"",
-    "build": "ngc -p tsconfig.json;",
+    "prebuild": "rimraf ./lib && npm uninstall @types/chai @types/sinon-chai",
+    "postbuild": "npm install @types/chai@3.4.31 @types/sinon-chai@2.7.26 && rimraf 'src/**/*.ngfactory.ts'",
+    "build": "ngc -p tsconfig.json",
     "test": "rimraf coverage && npm run lint && npm run cover",
     "mocha": "mocha --opts mocha.opts",
     "lint": "tslint 'src/**/*.ts' 'examples/counter/**.ts' --exclude 'examples/counter/node_modules'",

--- a/src/ng-redux.module.ts
+++ b/src/ng-redux.module.ts
@@ -1,24 +1,16 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { NgRedux } from './components/ng-redux';
 import { DevToolsExtension } from './components/dev-tools';
 
-@NgModule({})
-export class NgReduxModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgReduxModule,
-      providers: provideRedux(),
-    };
-  }
-};
 
 export function _ngReduxFactory() {
   return new NgRedux(null);
 }
 
-export function provideRedux(): any[] {
-  return [
-    { provide: NgRedux, useFactory: _ngReduxFactory },
+@NgModule({
+  providers: [
     DevToolsExtension,
-  ];
-}
+    { provide: NgRedux, useFactory: _ngReduxFactory }
+  ]
+})
+export class NgReduxModule { };


### PR DESCRIPTION
It seems the whole complexity with `NgReduxModule.forRoot()` is not necessary. Refactoring this to a simple providers array seems to fix the build problems in #282.