### PR TITLE
docs(epics): import mergeMap operator patch

### DIFF
--- a/docs/epics.md
+++ b/docs/epics.md
@@ -49,6 +49,7 @@ import { ActionsObservable } from 'redux-observable';
 import { SessionActions } from '../actions/session.actions';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 


### PR DESCRIPTION
Without this, the operator won't be defined. Which is prolly why when @jcperez-ch tried to use `flatMap` (which is *still* a supported alias of `mergeMap`) it wasn't there--you have to import `mergeMap` to get the `flatMap` alias.